### PR TITLE
Add sliding window, partitioning, and merging two-pointer lessons

### DIFF
--- a/two-pointers/detect-cycle-in-linked-list.md
+++ b/two-pointers/detect-cycle-in-linked-list.md
@@ -69,3 +69,10 @@ List: `1 → 2 → 3 → 4 → 2 (cycle back)`
 Now your turn:\
 👉 Suppose the list is `1 → 2 → 3 → null`.\
 On the first move: where are `slow` and `fast`, and what happens next?
+---
+Answer:
+- After the first move, `slow` is at node 2 and `fast` jumps to node 3.
+- On the next loop check, `fast.next` is `null`, so the loop stops and we conclude there is **no cycle**.
+
+---
+[Go to find-middle-of-linked-list.md](find-middle-of-linked-list.md)

--- a/two-pointers/dutch-national-flag.md
+++ b/two-pointers/dutch-national-flag.md
@@ -1,0 +1,63 @@
+Alright, time for the **Dutch National Flag** problem.
+
+### Problem
+
+Given an array `nums` consisting only of `0`, `1`, and `2`, sort it in-place so that all 0s come first, then 1s, then 2s.
+
+Example:
+
+- `nums = [2,0,2,1,1,0]` → becomes `[0,0,1,1,2,2]`.
+
+---
+
+### Step 1: Setup
+
+- `low = 0` (end of the 0s region)
+- `mid = 0` (current element)
+- `high = n-1` (start of the 2s region)
+
+We'll expand regions `[0..low-1] = 0`, `[low..mid-1] = 1`, `[high+1..n-1] = 2`.
+
+---
+
+### Step 2: Process while `mid <= high`
+
+1.  If `nums[mid] == 0`:
+    - Swap `nums[low]` and `nums[mid]`.
+    - Increment both `low++` and `mid++`.
+2.  Else if `nums[mid] == 1`:
+    - It's in the correct middle region.
+    - Just `mid++`.
+3.  Else (`nums[mid] == 2`):
+    - Swap `nums[mid]` and `nums[high]`.
+    - Decrement `high--`.
+    - Do **not** increment `mid` yet (need to examine the swapped-in value).
+
+---
+
+### Example Run: `nums = [2,0,2,1,1,0]`
+
+- Start: `low=0`, `mid=0`, `high=5`, array `[2,0,2,1,1,0]`
+- `nums[mid]=2` → swap with index 5 → array `[0,0,2,1,1,2]`, `high=4`
+- Now `nums[mid]=0` → swap with `low` (already 0) → array `[0,0,2,1,1,2]`, `low=1`, `mid=1`
+- `nums[mid]=0` → swap with `low` (same spot) → `low=2`, `mid=2`
+- `nums[mid]=2` → swap with `high=4` → array `[0,0,1,1,2,2]`, `high=3`
+- `nums[mid]=1` → `mid=3`
+- `nums[mid]=1` → `mid=4` which is > `high`, loop stops.
+
+Result: `[0,0,1,1,2,2]`.
+
+---
+
+Now your turn:\
+👉 In that run, what happens when `mid` is at index `2` (value `2`)? Describe the swap and pointer updates.
+
+---
+
+Answer:
+- We swap `nums[2]` with `nums[high]` (`high=4`, value `1`).
+- Array becomes `[0,0,1,1,2,2]`.
+- `high` decrements to `3`, while `mid` stays at `2` to inspect the new value (which is now `1`).
+
+---
+[Go to partition-array-around-pivot.md](partition-array-around-pivot.md)

--- a/two-pointers/find-middle-of-linked-list.md
+++ b/two-pointers/find-middle-of-linked-list.md
@@ -1,0 +1,64 @@
+Alright, let's find the middle node of a linked list with slow-fast pointers.
+
+### Problem
+
+Given the head of a singly linked list, return the middle node.\
+If there are two middle nodes, return the **second** middle.
+
+Example:
+
+- `1 → 2 → 3 → 4 → 5` → return node with value `3`.
+- `1 → 2 → 3 → 4` → return node with value `3` (the second middle).
+
+---
+
+### Step 1: Setup
+
+- `slow = head`
+- `fast = head`
+
+Both start at the beginning.
+
+---
+
+### Step 2: Traverse while `fast` and `fast.next` exist
+
+1.  Move `slow = slow.next` (one step).
+2.  Move `fast = fast.next.next` (two steps).
+3.  Repeat until `fast` can't move two steps.
+
+---
+
+### Step 3: When the loop stops
+
+- If `fast` is `null` or `fast.next` is `null`, the loop ends.\
+- `slow` now points to the middle node.
+- On even length lists, `slow` lands on the second middle because `fast` jumps two steps at a time.
+
+---
+
+### Example Run
+
+List: `1 → 2 → 3 → 4 → 5`
+
+- Start: `slow=1`, `fast=1`
+- Move: `slow=2`, `fast=3`
+- Move: `slow=3`, `fast=5`
+- Next check: `fast.next` is `null` → stop → answer is node `3`.
+
+Time: **O(n)**. Space: **O(1)**.
+
+---
+
+Now your turn:\
+👉 For the list `1 → 2 → 3 → 4`, what value does `slow` point to when the loop exits, and why?
+
+---
+
+Answer:
+- Iteration 1: `slow=2`, `fast=3`.
+- Next loop check: `fast.next` is `null`, so we stop and return `slow`, which is node `3`.
+- We return the second middle in even-length lists because `fast` leaps two steps at a time.
+
+---
+[Go to sliding-window.md](sliding-window.md)

--- a/two-pointers/fruits-into-baskets.md
+++ b/two-pointers/fruits-into-baskets.md
@@ -1,0 +1,67 @@
+Let's practice **Fruit Into Baskets** (LeetCode 904) with the sliding window template.
+
+### Problem
+
+You have a row of trees represented by `fruits[i]` (fruit type at tree `i`). You can carry at most **two types** of fruit at a time, but you may pick as many fruits as you want from consecutive trees. Return the maximum number of fruits you can pick in a row.
+
+Example:
+
+- `fruits = [1,2,3,2,2]` → answer is `4` (pick from indices 1-4: `[2,3,2,2]`).
+
+---
+
+### Step 1: Setup
+
+- `left = 0`
+- Map `count` for fruit frequencies inside the current window
+- `best = 0`
+
+---
+
+### Step 2: Expand with `right`
+
+For each index `right`:
+
+1.  Add `fruits[right]` to the map.
+2.  While the map holds more than 2 keys (more than two fruit types):
+    - Decrement `fruits[left]` in the map.
+    - If a count hits 0, remove that key.
+    - Move `left++`.
+
+---
+
+### Step 3: Update the answer
+
+- After the shrinking loop, the window is valid (at most two types).
+- Update `best = max(best, right - left + 1)`.
+
+Time: **O(n)**. Space: **O(1)** (at most 3 fruit types in map during shrinking).
+
+---
+
+### Example Run: `fruits = [1,2,3,2,2]`
+
+- `right=0`: window `[1]` → map `{1:1}` → best=1
+- `right=1`: window `[1,2]` → map `{1:1,2:1}` → best=2
+- `right=2`: add `3` → map `{1:1,2:1,3:1}` → too many types → shrink:
+  - Drop `fruits[0]=1` → map `{1:0,2:1,3:1}` → remove key `1` → `{2:1,3:1}` → left=1
+  - Window now `[2,3]` → size 2 → best stays 2
+- `right=3`: add `2` → map `{2:2,3:1}` → window `[2,3,2]` → best=3
+- `right=4`: add `2` → map `{2:3,3:1}` → window `[2,3,2,2]` → best=4
+
+Answer = 4.
+
+---
+
+Now your turn:\
+👉 In that example, what exactly happened to the window when we processed index `2` (fruit type `3`)? Describe `left`, the map, and the resulting window after shrinking.
+
+---
+
+Answer:
+- Adding the `3` made the map `{1:1,2:1,3:1}` (three types).
+- We shrank from the left: removed tree at index `0` (fruit `1`), so `left` moved to `1` and the map became `{2:1,3:1}`.
+- The window settled on indices `[1,2]` (`[2,3]`) before continuing.
+
+---
+[Go to partitioning.md](partitioning.md)

--- a/two-pointers/intersection-of-two-sorted-arrays.md
+++ b/two-pointers/intersection-of-two-sorted-arrays.md
@@ -1,0 +1,62 @@
+One more merge-style task: **Intersection of Two Sorted Arrays**.
+
+### Problem
+
+Given two sorted arrays (possibly with duplicates), return their intersection as a list of unique values.
+
+Example:
+
+- `A = [1,2,2,3,4]`
+- `B = [2,2,4,6]`
+- Intersection: `[2,4]`
+
+---
+
+### Step 1: Setup
+
+- `i = 0` (pointer in `A`)
+- `j = 0` (pointer in `B`)
+- `result = []`
+
+---
+
+### Step 2: Walk the arrays
+
+While `i < len(A)` and `j < len(B)`:
+
+1.  If `A[i] == B[j]`:
+    - If `result` is empty or `result[-1] != A[i]`, append `A[i]`.
+    - Move both pointers: `i++`, `j++`.
+2.  Else if `A[i] < B[j]`:
+    - Move `i++` (need a larger value in `A`).
+3.  Else (`A[i] > B[j]`):
+    - Move `j++` (need a larger value in `B`).
+
+Skipping duplicates via the last-added check keeps the intersection unique.
+
+---
+
+### Example Run
+
+- `i=0 (1)`, `j=0 (2)` → `1 < 2` → `i=1`
+- `i=1 (2)`, `j=0 (2)` → equal → append `2`, move both (`i=2`, `j=1`)
+- `i=2 (2)`, `j=1 (2)` → equal, but last result already `2` → skip append, move both (`i=3`, `j=2`)
+- `i=3 (3)`, `j=2 (4)` → `3 < 4` → `i=4`
+- `i=4 (4)`, `j=2 (4)` → equal → append `4`, move both (`i=5`, `j=3`)
+- Loop ends → result `[2,4]`
+
+Time: **O(m + n)**. Space: **O(1)** extra besides output.
+
+---
+
+Now your turn:\
+👉 Why do we advance **both** pointers when we find a common value, instead of just one of them?
+
+---
+
+Answer:
+- That matching value has been fully consumed from both arrays—advancing both ensures we look at the next unseen candidates.
+- If we advanced only one pointer, we'd compare the same number again and risk infinite loops or duplicate results.
+
+---
+[Back to overview.md](overview.md)

--- a/two-pointers/longest-substring-without-repeating-characters.md
+++ b/two-pointers/longest-substring-without-repeating-characters.md
@@ -1,0 +1,65 @@
+Alright, let's solve **Longest Substring Without Repeating Characters** with the sliding window pattern.
+
+### Problem
+
+Given a string `s`, return the length of the longest substring without repeating characters.
+
+Example:
+
+- `s = "abcabcbb"` → answer is `3` (substring `"abc"`).
+
+---
+
+### Step 1: Setup
+
+- `left = 0`
+- Hash map `count` to track how many times each character appears in the current window
+- `best = 0` to track the longest valid window so far
+
+---
+
+### Step 2: Expand with `right`
+
+For each index `right` from `0` to `n-1`:
+
+1.  Include `s[right]` in the window: `count[s[right]]++`.
+2.  While the current character count is > 1 (duplicate inside window):
+    - Decrement `count[s[left]]`.
+    - Move `left++` to shrink the window until it's valid again.
+
+---
+
+### Step 3: Update the answer
+
+- After the shrinking loop, the window `[left, right]` has all unique characters.
+- Update `best = max(best, right - left + 1)`.
+
+Time: **O(n)** because each pointer moves at most `n` times.\
+Space: **O(min(n, alphabet))** for the map.
+
+---
+
+### Example Run: `s = "abcabcbb"`
+
+- `right=0` → add `'a'` → window `"a"` → best=1
+- `right=1` → add `'b'` → window `"ab"` → best=2
+- `right=2` → add `'c'` → window `"abc"` → best=3
+- `right=3` → add `'a'` → duplicate `'a'` → shrink `left` to 1 → window `"bca"`
+- `right=4` → add `'b'` → duplicate `'b'` → shrink until window `"cab"`
+- ... continue. Final best remains `3`.
+
+---
+
+Now your turn:\
+👉 Suppose `s = "abba"`. When `right` is at index `2` (the second `'b'`), where does `left` end up after the shrinking loop, and why?
+
+---
+
+Answer:
+- Adding the second `'b'` makes `count['b'] = 2`.
+- Shrink: move `left` from 0 → 1 (drops `'a'`), but `count['b']` is still 2.
+- Shrink again: move `left` from 1 → 2 (drops the first `'b'`), now `count['b'] = 1`.
+- So `left` stops at index `2`, leaving the window `"b"` valid again.
+
+---
+[Go to minimum-size-subarray-sum.md](minimum-size-subarray-sum.md)

--- a/two-pointers/merge-step-merge-sort.md
+++ b/two-pointers/merge-step-merge-sort.md
@@ -1,0 +1,67 @@
+Let's apply the two-pointer merge step for arrays (classic merge sort move).
+
+### Problem
+
+Given two sorted arrays `A` and `B`, merge them into a single sorted array.
+
+Example:
+
+- `A = [1,4,7]`
+- `B = [2,3,6]`
+- Result: `[1,2,3,4,6,7]`
+
+---
+
+### Step 1: Setup
+
+- `i = 0` (pointer in `A`)
+- `j = 0` (pointer in `B`)
+- `merged = []`
+
+---
+
+### Step 2: Walk the arrays
+
+While `i < len(A)` and `j < len(B)`:
+
+1.  If `A[i] <= B[j]`, push `A[i]` into `merged` and `i++`.
+2.  Else push `B[j]` and `j++`.
+
+Only one pointer advances per iteration.
+
+---
+
+### Step 3: Append leftovers
+
+- If anything remains in `A`, append `A[i:]`.
+- If anything remains in `B`, append `B[j:]`.
+
+Merged array is done.
+
+Time: **O(m + n)**. Space: **O(m + n)** for the output (or use in-place trick if arrays have buffer space).
+
+---
+
+### Example Run
+
+- Start: `i=0 (1)`, `j=0 (2)` → take `1` → merged `[1]`, `i=1`
+- Compare `4` vs `2` → take `2` → merged `[1,2]`, `j=1`
+- Compare `4` vs `3` → take `3` → merged `[1,2,3]`, `j=2`
+- Compare `4` vs `6` → take `4` → merged `[1,2,3,4]`, `i=2`
+- Compare `7` vs `6` → take `6` → merged `[1,2,3,4,6]`, `j=3`
+- `B` exhausted → append remaining `[7]` → final `[1,2,3,4,6,7]`
+
+---
+
+Now your turn:\
+👉 If `A = [1,5,9]` and `B = [2,4,8,10]`, what happens when we compare `5` and `4`, and which pointer moves?
+
+---
+
+Answer:
+- Since `4 < 5`, we take `4` from `B`.
+- Append it to the merged array, move `j++` (pointer in `B`).
+- Pointer `i` stays on `5` for the next comparison.
+
+---
+[Go to intersection-of-two-sorted-arrays.md](intersection-of-two-sorted-arrays.md)

--- a/two-pointers/merge-two-sorted-lists.md
+++ b/two-pointers/merge-two-sorted-lists.md
@@ -1,0 +1,73 @@
+Let's merge two sorted linked lists using the two-pointer dance.
+
+### Problem
+
+Given the heads of two sorted linked lists `list1` and `list2`, merge them into a single sorted list and return its head.
+
+Example:
+
+- `list1 = 1 → 2 → 4`
+- `list2 = 1 → 3 → 4`
+- Result: `1 → 1 → 2 → 3 → 4 → 4`
+
+---
+
+### Step 1: Setup
+
+- Create a dummy node `dummy` and pointer `tail = dummy`.
+- Pointers `p1 = list1`, `p2 = list2`.
+
+`tail` always points to the last node in the merged list.
+
+---
+
+### Step 2: Walk through both lists
+
+While `p1` and `p2` are not null:
+
+1.  If `p1.val <= p2.val`:
+    - `tail.next = p1`
+    - Move `p1 = p1.next`
+2.  Else:
+    - `tail.next = p2`
+    - Move `p2 = p2.next`
+3.  Move `tail = tail.next`
+
+We always attach the smaller current node.
+
+---
+
+### Step 3: Attach the remainder
+
+- After the loop, exactly one list is non-empty.
+- `tail.next = (p1 ? p1 : p2)`
+- Return `dummy.next` as the new head.
+
+Time: **O(m + n)**. Space: **O(1)** extra (we reuse nodes).
+
+---
+
+### Example Run
+
+- Start: `p1=1`, `p2=1`, `tail` at dummy.
+- Compare 1 vs 1 → take from `p1` (tie-breaker) → merged `1`, `p1=2`, `tail` moves.
+- Compare 2 vs 1 → take from `p2` → merged `1 → 1`, `p2=3`.
+- Compare 2 vs 3 → take from `p1` → merged `1 → 1 → 2`, `p1=4`.
+- Compare 4 vs 3 → take from `p2` → merged `... → 3`, `p2=4`.
+- Compare 4 vs 4 → take from `p1` → merged `... → 4`, `p1=null`.
+- Attach remainder (`p2=4`) → final list `1 → 1 → 2 → 3 → 4 → 4`.
+
+---
+
+Now your turn:\
+👉 At the very first comparison (1 vs 1), why is it okay to choose from `list1`, and what keeps the result sorted when values tie?
+
+---
+
+Answer:
+- Either list's node can go first when values tie—the lists are already sorted.
+- By picking one and advancing its pointer, we still compare the next smallest remaining value across both lists.
+- The untouched list keeps its order, so the merged output remains sorted.
+
+---
+[Go to merge-step-merge-sort.md](merge-step-merge-sort.md)

--- a/two-pointers/merging.md
+++ b/two-pointers/merging.md
@@ -1,0 +1,41 @@
+// TODO: needs rewriting
+Finally, let's wrap with **Category 5: Merging / Two Sequences**.
+
+---
+
+### 🔹 Category 5: Merging / Two Sequences
+
+**Goal**: Walk through two sorted sequences simultaneously, combining or comparing them.
+
+**Setup**:
+
+- One pointer per sequence (or per list/array).
+- Advance the pointer that points to the "smaller" item (or the one you've consumed).
+- Build the merged output or compute relationships (intersection, difference, etc.).
+
+---
+
+### When this pattern appears
+
+- Merge step of merge sort (combine two sorted arrays).
+- Merging two sorted linked lists.
+- Finding intersection/union of two sorted arrays.
+- Comparing version numbers, iterating through meeting schedules, etc.
+
+Any time you have **two sorted streams**, think of parallel pointers.
+
+---
+
+### Problems on deck
+
+- Merge two sorted linked lists.
+- Merge step in merge sort (two sorted arrays).
+- Intersection of two sorted arrays.
+
+---
+
+// TODO: needs rewriting
+Ready to put two streams side by side?\
+👉 Let's start with **Merge Two Sorted Linked Lists**.
+
+[Go to merge-two-sorted-lists.md](merge-two-sorted-lists.md)

--- a/two-pointers/minimum-size-subarray-sum.md
+++ b/two-pointers/minimum-size-subarray-sum.md
@@ -1,0 +1,72 @@
+Let's tackle **Minimum Size Subarray Sum** using the sliding window breathing pattern.
+
+### Problem
+
+Given an array of positive integers `nums` and an integer `target`, return the minimal length of a contiguous subarray whose sum is at least `target`. If no such subarray exists, return `0`.
+
+Example:
+
+- `target = 7`, `nums = [2,3,1,2,4,3]` → answer is `2` (subarray `[4,3]`).
+
+---
+
+### Step 1: Setup
+
+- `left = 0`
+- `currentSum = 0`
+- `best = Infinity` (or `n + 1`) to track the shortest valid window
+
+---
+
+### Step 2: Expand with `right`
+
+For each index `right` from `0` to `n-1`:
+
+1.  Add `nums[right]` to `currentSum`.
+2.  While `currentSum >= target`:
+    - Update `best = min(best, right - left + 1)`.
+    - Subtract `nums[left]` from `currentSum` and move `left++` to try shrinking.
+
+The inner loop keeps shrinking until the window is no longer valid. Every time we enter it, we record a candidate length.
+
+---
+
+### Step 3: Final answer
+
+- If `best` was never updated, return `0`.
+- Otherwise return `best`.
+
+Time: **O(n)**. Space: **O(1)**.
+
+---
+
+### Example Run: `target = 7`, `nums = [2,3,1,2,4,3]`
+
+- `right=0`: sum=2 → <7
+- `right=1`: sum=5 → <7
+- `right=2`: sum=6 → <7
+- `right=3`: sum=8 → ≥7 → best=4 → shrink left to 1 → sum=6
+- `right=4`: add 4 → sum=10 → shrinking loop:
+  - best = min(4, 4) = 4 → subtract `nums[1] = 3` → sum=7 → left=2
+  - still ≥7 → best = min(4, 3) = 3 → subtract `nums[2] = 1` → sum=6 → left=3
+- `right=5`: add 3 → sum=9 → shrinking loop:
+  - best = min(3, 3) = 3 → subtract `nums[3] = 2` → sum=7 → left=4
+  - still ≥7 → best = min(3, 2) = 2 → subtract `nums[4] = 4` → sum=3 → left=5
+
+Final answer = 2.
+
+---
+
+Now your turn:\
+👉 In that same run, when `right` hits index `4` (value `4`), what new `best` length do we record and where does `left` land afterward?
+
+---
+
+Answer:
+- After adding `4`, the window sum is `10`.
+- First shrink: best stays `4`, `left` moves to `2`, sum becomes `7`.
+- Second shrink: best updates to `3`, `left` moves to `3`, sum becomes `6`.
+- So the new recorded best length is `3`, and `left` finishes at index `3` once the window is valid again.
+
+---
+[Go to fruits-into-baskets.md](fruits-into-baskets.md)

--- a/two-pointers/partition-array-around-pivot.md
+++ b/two-pointers/partition-array-around-pivot.md
@@ -1,0 +1,62 @@
+Next up: **Partition Array Around a Pivot** (a quicksort classic).
+
+### Problem
+
+Given an array `nums` and a pivot value `x`, rearrange the array in-place so that all elements `< x` appear before all elements `>= x`.
+
+Example:
+
+- `nums = [9,12,3,5,14,10,10]`, `x = 10` → one valid partition is `[9,5,3,12,14,10,10]`.
+
+The relative order inside each side doesn't matter.
+
+---
+
+### Step 1: Setup
+
+- `left = 0`
+- `right = n-1`
+
+We'll grow the `< x` region from the left and the `>= x` region from the right.
+
+---
+
+### Step 2: Process while `left <= right`
+
+1.  If `nums[left] < x`, it's already on the correct side → `left++`.
+2.  Else if `nums[right] >= x`, it's already on the right side → `right--`.
+3.  Otherwise (`nums[left] >= x` and `nums[right] < x`):
+    - Swap `nums[left]` and `nums[right]`.
+    - Move both pointers: `left++`, `right--`.
+
+The key idea: expand the correct zones by skipping good values and swapping misplaced ones.
+
+---
+
+### Example Run: `nums = [9,12,3,5,14,10,10]`, `x = 10`
+
+- Start: `left=0`, `right=6`
+- `nums[left]=9 < 10` → `left=1`
+- `nums[left]=12 ≥ 10`, `nums[right]=10 ≥ 10` → `right=5`
+- `nums[right]=10 ≥ 10` → `right=4`
+- `nums[right]=14 ≥ 10` → `right=3`
+- Now `nums[left]=12 ≥ 10`, `nums[right]=5 < 10` → swap → array `[9,5,3,12,14,10,10]`, `left=2`, `right=2`
+- `nums[left]=3 < 10` → `left=3`
+- Loop stops (`left > right`). Partition done.
+
+Result: first three numbers `< 10`, rest `>= 10`.
+
+---
+
+Now your turn:\
+👉 In that process, why did we move `right` from 6 down to 3 **before** the swap, and what invariant were we maintaining?
+
+---
+
+Answer:
+- Every time `nums[right] >= 10`, it's already in the right-side region, so we simply moved `right--` to shrink that region inward.
+- We only stop when `nums[right] < 10`, giving us a value that belongs on the left side.
+- That invariant keeps everything beyond `right` firmly `>= 10`, making the eventual swap correct.
+
+---
+[Go to merging.md](merging.md)

--- a/two-pointers/partitioning.md
+++ b/two-pointers/partitioning.md
@@ -1,0 +1,47 @@
+// TODO: needs rewriting
+Let's slide into **Category 4: Partitioning / Rearrangement with Two Pointers**.
+
+---
+
+### 🔹 Category 4: Partitioning / Rearrangement
+
+**Goal**: Reorder elements in-place so that parts of the array satisfy certain conditions.
+
+**Setup**:
+
+- Usually one pointer starts from the left, another from the right.
+- Swap elements that are "out of place" until each region is clean.
+- Often paired with a third pointer tracking the current index.
+
+---
+
+### When this pattern shows up
+
+- Grouping elements by type/value (0s,1s,2s or negatives/positives).
+- Partitioning around a pivot (quicksort, Dutch National Flag).
+- Reordering arrays in-place without extra memory.
+
+---
+
+### Mindset
+
+- Decide the **regions** you want (e.g., `< pivot`, `== pivot`, `> pivot`).
+- Maintain boundaries for those regions as pointers.
+- Move or swap elements to expand the correct region.
+
+---
+
+### Problems we'll tackle next
+
+- Dutch National Flag (sort colors 0,1,2).
+- Partition array around a pivot.
+
+These unlock many in-place reordering tasks.
+
+---
+
+// TODO: needs rewriting
+Ready for a classic?\
+👉 Let's practice the **Dutch National Flag** problem next.
+
+[Go to dutch-national-flag.md](dutch-national-flag.md)

--- a/two-pointers/sliding-window.md
+++ b/two-pointers/sliding-window.md
@@ -1,0 +1,50 @@
+// TODO: needs rewriting
+Time to move into **Category 3: Sliding Window (Same Direction Pointers)**.
+
+---
+
+### 🔹 Category 3: Sliding Window (Grow & Shrink)
+
+**Setup**:
+
+- Both pointers (`left` and `right`) start at index 0.
+- `right` expands the window.
+- `left` shrinks the window when a condition breaks.
+- We maintain some running state (sum, frequency map, unique count, etc.).
+
+---
+
+### When to reach for sliding window
+
+- Problem talks about **subarrays or substrings**.
+- There's a **constraint** you must keep inside the window (e.g., sum ≤ target, at most K distinct characters, no repeats).
+- You want the **longest** or **shortest** window satisfying that constraint.
+
+---
+
+### Generic pattern
+
+1.  Initialize `left = 0`, state trackers (sum, map, counter, ...), best answer placeholder.
+2.  Expand with `right` one step at a time, updating the state.
+3.  While the state violates the condition, move `left` forward and undo its contribution.
+4.  Update the answer each time the state is valid.
+
+Think of it as **breathing**: inhale with `right`, exhale with `left`.
+
+---
+
+### Example problems we'll tackle
+
+- Longest substring without repeating characters.
+- Minimum size subarray sum ≥ target.
+- Fruit into baskets (at most two distinct types).
+
+Each one uses the same skeleton but tweaks the state we track.
+
+---
+
+// TODO: needs rewriting
+Ready to put this into action?\
+👉 Let's start with the classic **Longest Substring Without Repeating Characters**.
+
+[Go to longest-substring-without-repeating-characters.md](longest-substring-without-repeating-characters.md)


### PR DESCRIPTION
## Summary
- extend the cycle-detection walkthrough with the follow-up answer and a link to the next exercise
- add linked-list midpoint, sliding-window, partitioning, and merging study guides that match the existing ChatGPT study mode format
- cover classic problems such as longest substring without repeats, minimum subarray sum, fruit baskets, Dutch national flag, pivot partitioning, and merging/intersection patterns

## Testing
- not run (markdown-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d02c10c084832cb7224173d0635d72